### PR TITLE
added option to window events and weekend with a variety of window functions provided in gonum dsp package

### DIFF
--- a/forecast/options.go
+++ b/forecast/options.go
@@ -3,7 +3,56 @@ package forecast
 import (
 	"github.com/aouyang1/go-forecaster/changepoint"
 	"github.com/aouyang1/go-forecaster/event"
+	"gonum.org/v1/gonum/dsp/window"
 )
+
+const (
+	WindowBartlettHann    = "bartlett_hann"
+	WindowBlackman        = "blackman"
+	WindowBlackmanHarris  = "blackman_harris"
+	WindowBlackmanNuttall = "blackman_nuttall"
+	WindowFlatTop         = "flat_top"
+	WindowHamming         = "hamming"
+	WindowHann            = "hann"
+	WindowLanczos         = "lanczos"
+	WindowNuttall         = "nuttall"
+	WindowRectangular     = "rectangular"
+	WindowSine            = "sine"
+	WindowTriangular      = "triangular"
+)
+
+func WindowFunc(name string) func(seq []float64) []float64 {
+	var winFunc func(seq []float64) []float64
+	switch name {
+	case WindowBartlettHann:
+		winFunc = window.BartlettHann
+	case WindowBlackman:
+		winFunc = window.Blackman
+	case WindowBlackmanHarris:
+		winFunc = window.BlackmanHarris
+	case WindowBlackmanNuttall:
+		winFunc = window.BlackmanNuttall
+	case WindowFlatTop:
+		winFunc = window.FlatTop
+	case WindowHamming:
+		winFunc = window.Hamming
+	case WindowHann:
+		winFunc = window.Hann
+	case WindowLanczos:
+		winFunc = window.Lanczos
+	case WindowNuttall:
+		winFunc = window.Nuttall
+	case WindowRectangular:
+		winFunc = window.Rectangular
+	case WindowSine:
+		winFunc = window.Sine
+	case WindowTriangular:
+		winFunc = window.Triangular
+	default:
+		winFunc = window.Rectangular
+	}
+	return winFunc
+}
 
 // Options configures a forecast by specifying changepoints, seasonality order
 // and an optional regularization parameter where higher values removes more features
@@ -21,6 +70,7 @@ type Options struct {
 	DSTOptions     DSTOptions     `json:"dst_options"`
 	WeekendOptions WeekendOptions `json:"weekend_options"`
 	EventOptions   EventOptions   `json:"event_options"`
+	MaskWindow     string         `json:"mask_window"`
 }
 
 // NewDefaultOptions returns a set of default forecast options


### PR DESCRIPTION
added option to window events and weekend with a variety of window functions provided in gonum dsp package

This will help reduce jumps in the fit at the boundary of the weekends and events. For events the span may need to be extended depending on the behavior of how fast the event seasonality changes upon entering the event zone. Some window function take longer to ramp to full strength than others. 

By default use the existing Rectangular window but recommending Hann to start if jumps are creating issues in fits.