### PR TITLE
unroll float operations to improve performance of lasso

### DIFF
--- a/floatsunrolled/floatsunrolled.go
+++ b/floatsunrolled/floatsunrolled.go
@@ -1,3 +1,5 @@
+// floatsunrolled is inspired by the SIMD blog post
+// https://github.com/camdencheek/simd_blog/blob/main/main.go
 package floatsunrolled
 
 import "fmt"

--- a/floatsunrolled/floatsunrolled.go
+++ b/floatsunrolled/floatsunrolled.go
@@ -2,17 +2,26 @@
 // https://github.com/camdencheek/simd_blog/blob/main/main.go
 package floatsunrolled
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 const UnrollBatch = 4
 
+var (
+	ErrSliceLengthMismatch       = errors.New("slices must have equal lengths")
+	ErrSliceMul                  = fmt.Errorf("slice length must be multiple of %d", UnrollBatch)
+	ErrOutputSliceLengthMismatch = errors.New("output slice length not the same as input")
+)
+
 func Dot(a, b []float64) float64 {
 	if len(a) != len(b) {
-		panic("slices must have equal lengths")
+		panic(ErrSliceLengthMismatch)
 	}
 
 	if len(a)%UnrollBatch != 0 {
-		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+		panic(ErrSliceMul)
 	}
 
 	var sum float64
@@ -30,11 +39,11 @@ func Dot(a, b []float64) float64 {
 
 func Add(dst, s []float64) []float64 {
 	if len(dst) != len(s) {
-		panic("slices must have equal lengths")
+		panic(ErrSliceLengthMismatch)
 	}
 
 	if len(s)%UnrollBatch != 0 {
-		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+		panic(ErrSliceMul)
 	}
 
 	for i := 0; i < len(s); i += UnrollBatch {
@@ -50,17 +59,17 @@ func Add(dst, s []float64) []float64 {
 
 func SubTo(dst, s, t []float64) []float64 {
 	if len(s) != len(t) {
-		panic("slices must have equal lengths")
+		panic(ErrSliceLengthMismatch)
 	}
 
 	if len(s)%UnrollBatch != 0 {
-		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+		panic(ErrSliceMul)
 	}
 
 	if dst == nil {
 		dst = make([]float64, len(s))
 	} else if len(dst) != len(s) {
-		panic("output slice length not the same as input")
+		panic(ErrOutputSliceLengthMismatch)
 	}
 
 	for i := 0; i < len(s); i += UnrollBatch {
@@ -78,13 +87,13 @@ func SubTo(dst, s, t []float64) []float64 {
 
 func ScaleTo(dst []float64, c float64, s []float64) []float64 {
 	if len(s)%UnrollBatch != 0 {
-		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+		panic(ErrSliceMul)
 	}
 
 	if dst == nil {
 		dst = make([]float64, len(s))
 	} else if len(dst) != len(s) {
-		panic("output slice length not the same as input")
+		panic(ErrOutputSliceLengthMismatch)
 	}
 
 	for i := 0; i < len(s); i += UnrollBatch {

--- a/floatsunrolled/floatsunrolled.go
+++ b/floatsunrolled/floatsunrolled.go
@@ -1,0 +1,98 @@
+package floatsunrolled
+
+import "fmt"
+
+const UnrollBatch = 4
+
+func Dot(a, b []float64) float64 {
+	if len(a) != len(b) {
+		panic("slices must have equal lengths")
+	}
+
+	if len(a)%UnrollBatch != 0 {
+		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+	}
+
+	var sum float64
+	for i := 0; i < len(a); i += UnrollBatch {
+		aTmp := a[i : i+UnrollBatch : i+UnrollBatch]
+		bTmp := b[i : i+UnrollBatch : i+UnrollBatch]
+		s0 := aTmp[0] * bTmp[0]
+		s1 := aTmp[1] * bTmp[1]
+		s2 := aTmp[2] * bTmp[2]
+		s3 := aTmp[3] * bTmp[3]
+		sum += s0 + s1 + s2 + s3
+	}
+	return sum
+}
+
+func Add(dst, s []float64) []float64 {
+	if len(dst) != len(s) {
+		panic("slices must have equal lengths")
+	}
+
+	if len(s)%UnrollBatch != 0 {
+		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+	}
+
+	for i := 0; i < len(s); i += UnrollBatch {
+		dstTmp := dst[i : i+UnrollBatch : i+UnrollBatch]
+		sTmp := s[i : i+UnrollBatch : i+UnrollBatch]
+		dstTmp[0] += sTmp[0]
+		dstTmp[1] += sTmp[1]
+		dstTmp[2] += sTmp[2]
+		dstTmp[3] += sTmp[3]
+	}
+	return dst
+}
+
+func SubTo(dst, s, t []float64) []float64 {
+	if len(s) != len(t) {
+		panic("slices must have equal lengths")
+	}
+
+	if len(s)%UnrollBatch != 0 {
+		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+	}
+
+	if dst == nil {
+		dst = make([]float64, len(s))
+	} else if len(dst) != len(s) {
+		panic("output slice length not the same as input")
+	}
+
+	for i := 0; i < len(s); i += UnrollBatch {
+		dstTmp := dst[i : i+UnrollBatch : i+UnrollBatch]
+		sTmp := s[i : i+UnrollBatch : i+UnrollBatch]
+		tTmp := t[i : i+UnrollBatch : i+UnrollBatch]
+		dstTmp[0] = sTmp[0] - tTmp[0]
+		dstTmp[1] = sTmp[1] - tTmp[1]
+		dstTmp[2] = sTmp[2] - tTmp[2]
+		dstTmp[3] = sTmp[3] - tTmp[3]
+	}
+
+	return dst
+}
+
+func ScaleTo(dst []float64, c float64, s []float64) []float64 {
+	if len(s)%UnrollBatch != 0 {
+		panic(fmt.Sprintf("slice length must be multiple of %d", UnrollBatch))
+	}
+
+	if dst == nil {
+		dst = make([]float64, len(s))
+	} else if len(dst) != len(s) {
+		panic("output slice length not the same as input")
+	}
+
+	for i := 0; i < len(s); i += UnrollBatch {
+		dstTmp := dst[i : i+UnrollBatch : i+UnrollBatch]
+		sTmp := s[i : i+UnrollBatch : i+UnrollBatch]
+		dstTmp[0] = c * sTmp[0]
+		dstTmp[1] = c * sTmp[1]
+		dstTmp[2] = c * sTmp[2]
+		dstTmp[3] = c * sTmp[3]
+	}
+
+	return dst
+}

--- a/floatsunrolled/floatsunrolled_test.go
+++ b/floatsunrolled/floatsunrolled_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func checkPanic(t *testing.T, err error) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	if err != nil {
+		rErr, ok := r.(error)
+		assert.True(t, ok)
+		assert.EqualError(t, rErr, err.Error())
+		return
+	}
+
+	assert.Nil(t, r)
+}
+
 func TestDot(t *testing.T) {
 	testData := map[string]struct {
 		a        []float64
@@ -52,43 +67,32 @@ func TestDot(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	testData := map[string]struct {
-		a        []float64
-		b        []float64
+		dst      []float64
+		s        []float64
 		err      error
 		expected []float64
 	}{
 		"length mismatch": {
-			a:   []float64{1, 2, 3},
-			b:   []float64{1, 2},
+			dst: []float64{1, 2, 3},
+			s:   []float64{1, 2},
 			err: ErrSliceLengthMismatch,
 		},
 		"length multiple invalid": {
-			a:   []float64{1, 2, 3},
-			b:   []float64{1, 2, 3},
+			dst: []float64{1, 2, 3},
+			s:   []float64{1, 2, 3},
 			err: ErrSliceMul,
 		},
 		"valid": {
-			a:        []float64{1, 2, 3, 4},
-			b:        []float64{4, 3, 2, 1},
+			dst:      []float64{1, 2, 3, 4},
+			s:        []float64{4, 3, 2, 1},
 			expected: []float64{5, 5, 5, 5},
 		},
 	}
 
 	for name, td := range testData {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if td.err != nil {
-						err, ok := r.(error)
-						assert.True(t, ok)
-						assert.EqualError(t, err, td.err.Error())
-						return
-					}
-
-					assert.Nil(t, r)
-				}
-			}()
-			res := Add(td.a, td.b)
+			defer checkPanic(t, td.err)
+			res := Add(td.dst, td.s)
 			assert.Equal(t, td.expected, res)
 		})
 	}
@@ -133,18 +137,7 @@ func TestSubTo(t *testing.T) {
 
 	for name, td := range testData {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if td.err != nil {
-						err, ok := r.(error)
-						assert.True(t, ok)
-						assert.EqualError(t, err, td.err.Error())
-						return
-					}
-
-					assert.Nil(t, r)
-				}
-			}()
+			defer checkPanic(t, td.err)
 			res := SubTo(td.dst, td.s, td.t)
 			assert.Equal(t, td.expected, res)
 		})
@@ -184,18 +177,7 @@ func TestScaleTo(t *testing.T) {
 
 	for name, td := range testData {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if td.err != nil {
-						err, ok := r.(error)
-						assert.True(t, ok)
-						assert.EqualError(t, err, td.err.Error())
-						return
-					}
-
-					assert.Nil(t, r)
-				}
-			}()
+			defer checkPanic(t, td.err)
 			res := ScaleTo(td.dst, td.c, td.s)
 			assert.Equal(t, td.expected, res)
 		})

--- a/floatsunrolled/floatsunrolled_test.go
+++ b/floatsunrolled/floatsunrolled_test.go
@@ -1,0 +1,203 @@
+package floatsunrolled
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDot(t *testing.T) {
+	testData := map[string]struct {
+		a        []float64
+		b        []float64
+		err      error
+		expected float64
+	}{
+		"length mismatch": {
+			a:   []float64{1, 2, 3},
+			b:   []float64{1, 2},
+			err: ErrSliceLengthMismatch,
+		},
+		"length multiple invalid": {
+			a:   []float64{1, 2, 3},
+			b:   []float64{1, 2, 3},
+			err: ErrSliceMul,
+		},
+		"valid": {
+			a:        []float64{1, 2, 3, 4},
+			b:        []float64{4, 3, 2, 1},
+			expected: 20,
+		},
+	}
+
+	for name, td := range testData {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if td.err != nil {
+						err, ok := r.(error)
+						assert.True(t, ok)
+						assert.EqualError(t, err, td.err.Error())
+						return
+					}
+
+					assert.Nil(t, r)
+				}
+			}()
+			res := Dot(td.a, td.b)
+			assert.Equal(t, td.expected, res)
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	testData := map[string]struct {
+		a        []float64
+		b        []float64
+		err      error
+		expected []float64
+	}{
+		"length mismatch": {
+			a:   []float64{1, 2, 3},
+			b:   []float64{1, 2},
+			err: ErrSliceLengthMismatch,
+		},
+		"length multiple invalid": {
+			a:   []float64{1, 2, 3},
+			b:   []float64{1, 2, 3},
+			err: ErrSliceMul,
+		},
+		"valid": {
+			a:        []float64{1, 2, 3, 4},
+			b:        []float64{4, 3, 2, 1},
+			expected: []float64{5, 5, 5, 5},
+		},
+	}
+
+	for name, td := range testData {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if td.err != nil {
+						err, ok := r.(error)
+						assert.True(t, ok)
+						assert.EqualError(t, err, td.err.Error())
+						return
+					}
+
+					assert.Nil(t, r)
+				}
+			}()
+			res := Add(td.a, td.b)
+			assert.Equal(t, td.expected, res)
+		})
+	}
+}
+
+func TestSubTo(t *testing.T) {
+	testData := map[string]struct {
+		dst      []float64
+		s        []float64
+		t        []float64
+		err      error
+		expected []float64
+	}{
+		"length mismatch": {
+			s:   []float64{1, 2, 3},
+			t:   []float64{1, 2},
+			err: ErrSliceLengthMismatch,
+		},
+		"length multiple invalid": {
+			s:   []float64{1, 2, 3},
+			t:   []float64{1, 2, 3},
+			err: ErrSliceMul,
+		},
+		"valid no destination": {
+			s:        []float64{1, 2, 3, 4},
+			t:        []float64{4, 3, 2, 1},
+			expected: []float64{-3, -1, 1, 3},
+		},
+		"valid with destination": {
+			dst:      make([]float64, 4),
+			s:        []float64{1, 2, 3, 4},
+			t:        []float64{4, 3, 2, 1},
+			expected: []float64{-3, -1, 1, 3},
+		},
+		"invalid destination": {
+			dst: make([]float64, 3),
+			s:   []float64{1, 2, 3, 4},
+			t:   []float64{4, 3, 2, 1},
+			err: ErrOutputSliceLengthMismatch,
+		},
+	}
+
+	for name, td := range testData {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if td.err != nil {
+						err, ok := r.(error)
+						assert.True(t, ok)
+						assert.EqualError(t, err, td.err.Error())
+						return
+					}
+
+					assert.Nil(t, r)
+				}
+			}()
+			res := SubTo(td.dst, td.s, td.t)
+			assert.Equal(t, td.expected, res)
+		})
+	}
+}
+
+func TestScaleTo(t *testing.T) {
+	testData := map[string]struct {
+		dst      []float64
+		c        float64
+		s        []float64
+		err      error
+		expected []float64
+	}{
+		"length multiple invalid": {
+			s:   []float64{1, 2, 3},
+			err: ErrSliceMul,
+		},
+		"valid no destination": {
+			c:        3,
+			s:        []float64{1, 2, 3, 4},
+			expected: []float64{3, 6, 9, 12},
+		},
+		"valid with destination": {
+			dst:      make([]float64, 4),
+			c:        3,
+			s:        []float64{1, 2, 3, 4},
+			expected: []float64{3, 6, 9, 12},
+		},
+		"invalid destination": {
+			dst: make([]float64, 3),
+			c:   3,
+			s:   []float64{1, 2, 3, 4},
+			err: ErrOutputSliceLengthMismatch,
+		},
+	}
+
+	for name, td := range testData {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if td.err != nil {
+						err, ok := r.(error)
+						assert.True(t, ok)
+						assert.EqualError(t, err, td.err.Error())
+						return
+					}
+
+					assert.Nil(t, r)
+				}
+			}()
+			res := ScaleTo(td.dst, td.c, td.s)
+			assert.Equal(t, td.expected, res)
+		})
+	}
+}

--- a/floatsunrolled/floatsunrolled_test.go
+++ b/floatsunrolled/floatsunrolled_test.go
@@ -28,17 +28,17 @@ func TestDot(t *testing.T) {
 		err      error
 		expected float64
 	}{
-		"length mismatch": {
+		"dot length mismatch": {
 			a:   []float64{1, 2, 3},
 			b:   []float64{1, 2},
 			err: ErrSliceLengthMismatch,
 		},
-		"length multiple invalid": {
+		"dot length multiple invalid": {
 			a:   []float64{1, 2, 3},
 			b:   []float64{1, 2, 3},
 			err: ErrSliceMul,
 		},
-		"valid": {
+		"dot valid": {
 			a:        []float64{1, 2, 3, 4},
 			b:        []float64{4, 3, 2, 1},
 			expected: 20,
@@ -72,17 +72,17 @@ func TestAdd(t *testing.T) {
 		err      error
 		expected []float64
 	}{
-		"length mismatch": {
+		"add length mismatch": {
 			dst: []float64{1, 2, 3},
 			s:   []float64{1, 2},
 			err: ErrSliceLengthMismatch,
 		},
-		"length multiple invalid": {
+		"add length multiple invalid": {
 			dst: []float64{1, 2, 3},
 			s:   []float64{1, 2, 3},
 			err: ErrSliceMul,
 		},
-		"valid": {
+		"add valid": {
 			dst:      []float64{1, 2, 3, 4},
 			s:        []float64{4, 3, 2, 1},
 			expected: []float64{5, 5, 5, 5},
@@ -106,28 +106,28 @@ func TestSubTo(t *testing.T) {
 		err      error
 		expected []float64
 	}{
-		"length mismatch": {
+		"subto length mismatch": {
 			s:   []float64{1, 2, 3},
 			t:   []float64{1, 2},
 			err: ErrSliceLengthMismatch,
 		},
-		"length multiple invalid": {
+		"subto length multiple invalid": {
 			s:   []float64{1, 2, 3},
 			t:   []float64{1, 2, 3},
 			err: ErrSliceMul,
 		},
-		"valid no destination": {
+		"subto valid no destination": {
 			s:        []float64{1, 2, 3, 4},
 			t:        []float64{4, 3, 2, 1},
 			expected: []float64{-3, -1, 1, 3},
 		},
-		"valid with destination": {
+		"subto valid with destination": {
 			dst:      make([]float64, 4),
 			s:        []float64{1, 2, 3, 4},
 			t:        []float64{4, 3, 2, 1},
 			expected: []float64{-3, -1, 1, 3},
 		},
-		"invalid destination": {
+		"subto invalid destination": {
 			dst: make([]float64, 3),
 			s:   []float64{1, 2, 3, 4},
 			t:   []float64{4, 3, 2, 1},
@@ -152,22 +152,22 @@ func TestScaleTo(t *testing.T) {
 		err      error
 		expected []float64
 	}{
-		"length multiple invalid": {
+		"scaleto length multiple invalid": {
 			s:   []float64{1, 2, 3},
 			err: ErrSliceMul,
 		},
-		"valid no destination": {
+		"scaleto valid no destination": {
 			c:        3,
 			s:        []float64{1, 2, 3, 4},
 			expected: []float64{3, 6, 9, 12},
 		},
-		"valid with destination": {
+		"scaleto valid with destination": {
 			dst:      make([]float64, 4),
 			c:        3,
 			s:        []float64{1, 2, 3, 4},
 			expected: []float64{3, 6, 9, 12},
 		},
-		"invalid destination": {
+		"scaleto invalid destination": {
 			dst: make([]float64, 3),
 			c:   3,
 			s:   []float64{1, 2, 3, 4},

--- a/models/lasso_test.go
+++ b/models/lasso_test.go
@@ -233,7 +233,7 @@ func TestLassoAutoRegression(t *testing.T) {
 }
 
 func BenchmarkLassoRegression(b *testing.B) {
-	x, y, err := generateBenchData(1000, 100)
+	x, y, err := generateBenchData(100000, 100)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/models/lasso_test.go
+++ b/models/lasso_test.go
@@ -255,7 +255,7 @@ func TestLassoAutoRegression(t *testing.T) {
 }
 
 func BenchmarkLassoRegression(b *testing.B) {
-	nObs := 1000
+	nObs := 100000
 	nFeat := 100
 
 	data := make([][]float64, nObs)
@@ -275,13 +275,15 @@ func BenchmarkLassoRegression(b *testing.B) {
 		data2 = append(data2, float64(i))
 	}
 
+	x, err := mat_.NewDenseFromArray(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	y := mat.NewDense(nObs, 1, data2)
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		x, err := mat_.NewDenseFromArray(data)
-		if err != nil {
-			b.Error(err)
-			continue
-		}
-		y := mat.NewDense(nObs, 1, data2)
 		opt := NewDefaultLassoOptions()
 		opt.FitIntercept = false
 		model, err := NewLassoRegression(opt)

--- a/models/lasso_test.go
+++ b/models/lasso_test.go
@@ -136,17 +136,7 @@ func TestLassoRegression(t *testing.T) {
 			model, err := NewLassoRegression(td.opt)
 			require.Nil(t, err)
 
-			err = model.Fit(x, y)
-			require.Nil(t, err)
-
-			assert.InDelta(t, td.intercept, model.Intercept(), tol)
-
-			coef := model.Coef()
-			assert.InDeltaSlice(t, td.coef, coef, tol)
-
-			r2, err := model.Score(x, y)
-			require.Nil(t, err)
-			assert.InDelta(t, 1.0, r2, tol)
+			testModel(t, model, x, y, td.intercept, td.coef, tol)
 		})
 	}
 }
@@ -237,48 +227,16 @@ func TestLassoAutoRegression(t *testing.T) {
 			model, err := NewLassoAutoRegression(td.opt)
 			require.Nil(t, err)
 
-			err = model.Fit(x, y)
-			require.Nil(t, err)
-
-			assert.InDelta(t, td.intercept, model.Intercept(), tol)
-
-			coef := model.Coef()
-			assert.InDeltaSlice(t, td.coef, coef, tol)
-
-			r2, err := model.Score(x, y)
-			require.Nil(t, err)
-			assert.InDelta(t, 1.0, r2, tol)
+			testModel(t, model, x, y, td.intercept, td.coef, tol)
 		})
 	}
 }
 
 func BenchmarkLassoRegression(b *testing.B) {
-	nObs := 1000
-	nFeat := 100
-
-	data := make([][]float64, nObs)
-	for i := 0; i < nObs; i++ {
-		data[i] = make([]float64, nFeat)
-		for j := 0; j < nFeat; j++ {
-			val := float64(i*nFeat + j)
-			if j == 0 {
-				val = 1.0
-			}
-			data[i][j] = val
-		}
-	}
-
-	data2 := make([]float64, 0, nObs)
-	for i := 0; i < cap(data2); i++ {
-		data2 = append(data2, float64(i))
-	}
-
-	x, err := mat_.NewDenseFromArray(data)
+	x, y, err := generateBenchData(1000, 100)
 	if err != nil {
 		b.Fatal(err)
 	}
-
-	y := mat.NewDense(nObs, 1, data2)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/models/model.go
+++ b/models/model.go
@@ -1,0 +1,13 @@
+package models
+
+import (
+	"gonum.org/v1/gonum/mat"
+)
+
+type Model interface {
+	Fit(x, y mat.Matrix) error
+	Predict(x mat.Matrix) ([]float64, error)
+	Score(x, y mat.Matrix) (float64, error)
+	Intercept() float64
+	Coef() []float64
+}

--- a/models/util.go
+++ b/models/util.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"testing"
+
+	mat_ "github.com/aouyang1/go-forecaster/mat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/mat"
+)
+
+func testModel(t *testing.T, model Model, x, y mat.Matrix, intercept float64, coef []float64, tol float64) {
+	err := model.Fit(x, y)
+	require.Nil(t, err)
+
+	assert.InDelta(t, intercept, model.Intercept(), tol)
+
+	c := model.Coef()
+	assert.InDeltaSlice(t, coef, c, tol)
+
+	r2, err := model.Score(x, y)
+	require.Nil(t, err)
+	assert.InDelta(t, 1.0, r2, tol)
+}
+
+func generateBenchData(nObs, nFeat int) (mat.Matrix, mat.Matrix, error) {
+	data := make([][]float64, nObs)
+	for i := 0; i < nObs; i++ {
+		data[i] = make([]float64, nFeat)
+		for j := 0; j < nFeat; j++ {
+			val := float64(i*nFeat + j)
+			if j == 0 {
+				val = 1.0
+			}
+			data[i][j] = val
+		}
+	}
+
+	data2 := make([]float64, 0, nObs)
+	for i := 0; i < cap(data2); i++ {
+		data2 = append(data2, float64(i))
+	}
+
+	x, err := mat_.NewDenseFromArray(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	y := mat.NewDense(nObs, 1, data2)
+	return x, y, nil
+}


### PR DESCRIPTION
unroll float operations to improve performance of lasso

unroll by a factor of 4 for float operations improving model fit cpu performance by up to ~37%

```
BenchmarkLassoRegression-8   	      21	  51061528 ns/op	91726233 B/op	    4869 allocs/op

to

BenchmarkLassoRegression-8   	      37	  32036508 ns/op	163779863 B/op	     208 allocs/op
```
